### PR TITLE
rename gotoaerynosrepo to gotoaosrepo

### DIFF
--- a/src/content/docs/packaging/Workflow/basic-workflow.mdx
+++ b/src/content/docs/packaging/Workflow/basic-workflow.mdx
@@ -50,7 +50,7 @@ the following commands:
 
 ```bash
 # create a new tab or open a new terminal
-gotoaerynosrepo
+gotoaosrepo
 just create-local
 just index-local
 ```
@@ -179,7 +179,7 @@ To actually build a recipe, it is recommended that new packagers start out by bu
 
 ```bash
 # Go into the root of the AerynOS recipe directory 
-gotoaerynosrepo
+gotoaosrepo
 # change to the directory holding the nano recipe
 chpkg nano
 # bump the release number in the nano recipe
@@ -222,7 +222,7 @@ Often, it will be prudent to clean out the local repository after the associated
 accepted upstream.
 
 ```bash
-gotoaerynosrepo
+gotoaosrepo
 just clean-local
 sudo moss repo disable volatile
 sudo moss repo disable local

--- a/src/content/docs/packaging/Workflow/prerequisites.mdx
+++ b/src/content/docs/packaging/Workflow/prerequisites.mdx
@@ -45,10 +45,10 @@ Finally, execute the following in a new terminal tab:
 
 ```bash
 cd ~
-gotoaerynosrepo
+gotoaosrepo
 ```
 
-If the helpers script has been correctly loaded, the `gotoaerynosrepo` command should switch to
+If the helpers script has been correctly loaded, the `gotoaosrepo` command should switch to
 the directory containing the recipes/ git repository clone.
 
 
@@ -59,7 +59,7 @@ The `just` command runner should have been installed as part of `build-essential
 Run the following:
 
 ```bash
-gotoaerynosrepo
+gotoaosrepo
 just init
 ```
 


### PR DESCRIPTION
simplifies gotoaerynosrepo to be `gotoaosrepo`

which is added in https://github.com/AerynOS/recipes/pull/648