### PR TITLE
Update helper command to gotoaosrepo

### DIFF
--- a/src/content/docs/Packaging/Workflow/prerequisites.mdx
+++ b/src/content/docs/Packaging/Workflow/prerequisites.mdx
@@ -43,10 +43,10 @@ Finally, execute the following in a new terminal tab:
 
 ```bash
 cd ~
-gotoaerynosrepo
+gotoaosrepo
 ```
 
-If the helpers script has been correctly loaded, the `gotoaerynosrepo` command should switch to
+If the helpers script has been correctly loaded, the `gotoaosrepo` command should switch to
 the directory containing the recipes/ git repository clone.
 
 
@@ -57,7 +57,7 @@ The `just` command runner should have been installed as part of `build-essential
 Run the following:
 
 ```bash
-gotoaerynosrepo
+gotoaosrepo
 just init
 ```
 


### PR DESCRIPTION
The documentation on pre-requsites (https://aerynos.dev/packaging/workflow/prerequisites/) contains the wrong command to go to the repository root directory.

This change updates the pre-requisites page to specify the command as `gotoaosrepo` instead of `gotoaerynosrepo`.