### PR TITLE
Update Users/Getting Started/Requirements

### DIFF
--- a/src/content/docs/Users/Getting Started/requirements.mdx
+++ b/src/content/docs/Users/Getting Started/requirements.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
   BIOS/CSM mode is not supported. Please ensure that your system is set to UEFI mode.
 </Aside>
 
-- **Architecture:** x86_64
+- **Architecture:** x86_64-v2
 - **Firmware:** UEFI (CSM Support must be disabled)
 - **Processor (CPU):** Quad-core processor with a minimum clock speed of 2GHz
 - **System Memory (RAM):** 4GB or more
@@ -38,6 +38,5 @@ To successfully create a bootable USB drive for installing AerynOS, the followin
   - **Fedora Media Writer:** A reliable and user-friendly tool for creating bootable USB drives.
   - **Rufus:** A widely-used utility that provides advanced options for creating bootable USB drives.
   - **Balena Etcher:** A simple and user-friendly tool for creating bootable USB drives.
-  - **Ventoy:** An open-source tool that allows you to create a bootable USB drive for multiple ISO files.
 
 - **Additional Hardware:** A physical keyboard, mouse, and monitor (or screen) are required to interact with the installation process. Ensure that all these peripherals are properly connected to the system before starting the installation.


### PR DESCRIPTION
Make a couple of tweaks to specifiy x86_64-v2 as opposed to x86_64 and also to remove reference of ventoy as an image flashing software as we know users have had issues with this