### PR TITLE
Modify default "astro dev" behavior to bind to IP

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "astro": "^5.1.5",
     "sharp": "^0.32.5",
     "yaml": "^2.7.0"
+  },
+  "scripts": {
+    "dev": "astro dev --host"
   }
 }


### PR DESCRIPTION
Add the `--host` flag. Now the local build can be viewed on other machines on your network.