### PR TITLE
use relative links for internal pages and reorder packaging workflow pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -67,10 +67,10 @@ export default defineConfig({
               label: 'Workflow',
               items: [
                 { slug: 'packaging/workflow' },
-                { slug: 'packaging/workflow/updating-an-existing-recipe' },
-                { slug: 'packaging/workflow/creating-a-new-recipe' },
+                { slug: 'packaging/workflow/prerequisites' },
                 { slug: 'packaging/workflow/basic-workflow' },
-                { slug: 'packaging/workflow/prerequisites' }
+                { slug: 'packaging/workflow/creating-a-new-recipe' },
+                { slug: 'packaging/workflow/updating-an-existing-recipe' }
               ]
             },
             {

--- a/src/content/docs/AerynOS/faq.mdx
+++ b/src/content/docs/AerynOS/faq.mdx
@@ -186,7 +186,7 @@ If the use-case for the package you are proposing is in line with the ethos abov
 
 ### Where can I learn how to package for AerynOS?
 
-Consult the packaging documentation [here](https://aerynos.dev/packaging/).
+Consult the packaging documentation [here](/packaging/).
 
 In addition, consult the AerynOS [recipes/ repository](https://github.com/AerynOS/recipes).
 

--- a/src/content/docs/Packaging/Workflow/basic-workflow.mdx
+++ b/src/content/docs/Packaging/Workflow/basic-workflow.mdx
@@ -4,7 +4,7 @@ lastUpdated: 2025-06-23T00:00:00Z
 description: "Building packages locally and testing them"
 ---
 
-Once the [prerequisites](../prerequisites) have been handled, it is time to learn how to install
+Once the [prerequisites](/packaging/workflow/prerequisites/) have been handled, it is time to learn how to install
 newly built local moss-format `.stone` packages.
 
 

--- a/src/content/docs/Packaging/Workflow/updating-an-existing-recipe.mdx
+++ b/src/content/docs/Packaging/Workflow/updating-an-existing-recipe.mdx
@@ -8,7 +8,7 @@ This page details the process of updating a package that is already present in t
 Before updating the package yourself, please double check that there isn't already an outstanding PR for the update you want to make. Please also check if someone has created an update request issue in the [AerynOS recipes repository](https://github.com/AerynOS/recipes).
 
 ## Update your clone of the recipes repository
-Please refer to the [Basic Packaging Workflow](https://aerynos.dev/packaging/workflow/basic-workflow/) on how to create and update your local clone of the AerynOS repository on your own system before proceeding any further.
+Please refer to the [Basic Packaging Workflow](/packaging/workflow/basic-workflow/) on how to create and update your local clone of the AerynOS repository on your own system before proceeding any further.
 
 As a reminder, you want to ensure you have the volatile repository enabled and fully updated on your system.
 
@@ -88,7 +88,7 @@ This command does the following:
 
 ## Wider updates to a package
 
-If there are missing dependencies or you need to make further changes to the stone.yaml recipe file, you can either use nano to make changes to the stone.yaml from within your terminal or you can use a code editor such as zed which is pre-installed on AerynOS. Guidance on how to make changes to a stone.yaml file are covered in the [Create a new package recipe](https://aerynos.dev/packaging/workflow/creating-a-new-recipe/) page.
+If there are missing dependencies or you need to make further changes to the stone.yaml recipe file, you can either use nano to make changes to the stone.yaml from within your terminal or you can use a code editor such as zed which is pre-installed on AerynOS. Guidance on how to make changes to a stone.yaml file are covered in the [Create a new package recipe](/packaging/workflow/03-creating-a-new-recipe/) page.
 
 ## Build the package
 

--- a/src/content/docs/Packaging/Workflow/updating-an-existing-recipe.mdx
+++ b/src/content/docs/Packaging/Workflow/updating-an-existing-recipe.mdx
@@ -88,7 +88,7 @@ This command does the following:
 
 ## Wider updates to a package
 
-If there are missing dependencies or you need to make further changes to the stone.yaml recipe file, you can either use nano to make changes to the stone.yaml from within your terminal or you can use a code editor such as zed which is pre-installed on AerynOS. Guidance on how to make changes to a stone.yaml file are covered in the [Create a new package recipe](/packaging/workflow/03-creating-a-new-recipe/) page.
+If there are missing dependencies or you need to make further changes to the stone.yaml recipe file, you can either use nano to make changes to the stone.yaml from within your terminal or you can use a code editor such as zed which is pre-installed on AerynOS. Guidance on how to make changes to a stone.yaml file are covered in the [Create a new package recipe](/packaging/workflow/creating-a-new-recipe/) page.
 
 ## Build the package
 


### PR DESCRIPTION
It's best to use relative links rather than links to the deployed site. This makes the development and deployed environments internally consistent. i.e you will not be linked to the deployed page from the local dev server.

Also, I thought it would make more sense to have the prerequisites and basic-workflow pages appear first in the order since these are likely the first 2 pages a developer will need.