### PR TITLE
Desktop Environment page updates

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,133 +1,132 @@
 // @ts-check
-import { defineConfig } from 'astro/config'
-import starlight from '@astrojs/starlight'
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://aerynos.dev',
+  site: "https://aerynos.dev",
   integrations: [
     starlight({
       logo: {
-        dark: '@/images/logo.svg',
-        light: '@/images/logo-light-mode.svg',
+        dark: "@/images/logo.svg",
+        light: "@/images/logo-light-mode.svg",
         replacesTitle: false,
       },
-      title: 'AerynOS Docs',
+      title: "AerynOS Docs",
       social: {
-        github: 'https://github.com/AerynOS/dotdev',
+        github: "https://github.com/AerynOS/dotdev",
       },
-      customCss: [
-        '@/styles/global.css',
-      ],
+      customCss: ["@/styles/global.css"],
       sidebar: [
         {
-            label: 'AerynOS',
-            items: [
-                { slug: 'aerynos' },
-                { slug: 'aerynos/overview' },
-                { slug: 'aerynos/philosophy' },
-                { slug: 'aerynos/roadmap' },
-                { slug: 'aerynos/faq' },
-                { slug: 'aerynos/contribute' }
-            ]
+          label: "AerynOS",
+          items: [
+            { slug: "aerynos" },
+            { slug: "aerynos/overview" },
+            { slug: "aerynos/philosophy" },
+            { slug: "aerynos/roadmap" },
+            { slug: "aerynos/faq" },
+            { slug: "aerynos/contribute" },
+          ],
         },
         {
-          label: 'Users',
+          label: "Users",
           items: [
-            { slug: 'users' },
+            { slug: "users" },
             {
-              label: 'Getting Started',
+              label: "Getting Started",
               items: [
-                { slug: 'users/getting-started' },
-                { slug: 'users/getting-started/requirements' },
-                { slug: 'users/getting-started/downloading' },
+                { slug: "users/getting-started" },
+                { slug: "users/getting-started/requirements" },
+                { slug: "users/getting-started/downloading" },
                 {
-                  slug: 'users/getting-started/creating-the-live-enviroment'
+                  slug: "users/getting-started/creating-the-live-enviroment",
                 },
                 {
-                  slug: 'users/getting-started/booting-the-live-environment'
-                }
-              ]
+                  slug: "users/getting-started/booting-the-live-environment",
+                },
+              ],
             },
             {
-              label: 'Desktops',
+              label: "Desktops",
               items: [
-                { slug: 'users/desktops' },
-                { slug: 'users/desktops/cosmic' },
-                { slug: 'users/desktops/gnome' }
-              ]
-            }
-          ]
+                { slug: "users/desktops" },
+                { slug: "users/desktops/cosmic" },
+                { slug: "users/desktops/gnome" },
+                { slug: "users/desktops/plasma" },
+              ],
+            },
+          ],
         },
         {
-          label: 'Packaging',
+          label: "Packaging",
           items: [
-            { slug: 'packaging' },
+            { slug: "packaging" },
             {
-              label: 'Workflow',
+              label: "Workflow",
               items: [
-                { slug: 'packaging/workflow' },
-                { slug: 'packaging/workflow/prerequisites' },
-                { slug: 'packaging/workflow/basic-workflow' },
-                { slug: 'packaging/workflow/creating-a-new-recipe' },
-                { slug: 'packaging/workflow/updating-an-existing-recipe' }
-              ]
+                { slug: "packaging/workflow" },
+                { slug: "packaging/workflow/prerequisites" },
+                { slug: "packaging/workflow/basic-workflow" },
+                { slug: "packaging/workflow/creating-a-new-recipe" },
+                { slug: "packaging/workflow/updating-an-existing-recipe" },
+              ],
             },
             {
-              label: 'Recipes',
+              label: "Recipes",
               items: [
-                { slug: 'packaging/recipes' },
-                { slug: 'packaging/recipes/overview' },
-                { slug: 'packaging/recipes/upstreams' },
-                { slug: 'packaging/recipes/metadata' },
-                { slug: 'packaging/recipes/build-deps' },
-                { slug: 'packaging/recipes/package-definition' },
+                { slug: "packaging/recipes" },
+                { slug: "packaging/recipes/overview" },
+                { slug: "packaging/recipes/upstreams" },
+                { slug: "packaging/recipes/metadata" },
+                { slug: "packaging/recipes/build-deps" },
+                { slug: "packaging/recipes/package-definition" },
                 {
-                  label: 'Triggers',
+                  label: "Triggers",
                   items: [
-                    { slug: 'packaging/recipes/triggers' },
-                    { slug: 'packaging/recipes/triggers/overview' },
-                    { slug: 'packaging/recipes/triggers/tx-triggers' }
-                  ]
+                    { slug: "packaging/recipes/triggers" },
+                    { slug: "packaging/recipes/triggers/overview" },
+                    { slug: "packaging/recipes/triggers/tx-triggers" },
+                  ],
                 },
                 {
-                  label: 'System Accounts',
+                  label: "System Accounts",
                   items: [
-                    { slug: 'packaging/recipes/system-accounts' },
-                    { slug: 'packaging/recipes/system-accounts/groups' },
-                    { slug: 'packaging/recipes/system-accounts/overview' },
-                    { slug: 'packaging/recipes/system-accounts/users' }
-                  ]
-                }
-              ]
+                    { slug: "packaging/recipes/system-accounts" },
+                    { slug: "packaging/recipes/system-accounts/groups" },
+                    { slug: "packaging/recipes/system-accounts/overview" },
+                    { slug: "packaging/recipes/system-accounts/users" },
+                  ],
+                },
+              ],
             },
             {
-              label: 'Macros',
-              autogenerate: { directory: 'Packaging/Macros' }
+              label: "Macros",
+              autogenerate: { directory: "Packaging/Macros" },
             },
-          ]
+          ],
         },
-          {
-              label: 'Developers',
+        {
+          label: "Developers",
+          items: [
+            { slug: "developers" },
+            {
+              label: "Stone Format",
               items: [
-                  { slug: 'developers' },
-                  {
-                    label: 'Stone Format',
-                    items: [
-                        { slug: 'developers/stone' },
-                        { slug: 'developers/stone/header' },
-                        {
-                            label: 'V1',
-                            items: [
-                                { slug: 'developers/stone/v1' },
-                                { slug: 'developers/stone/v1/header' }
-                            ]
-                        }
-                    ]
-                  }
-              ]
-          }
+                { slug: "developers/stone" },
+                { slug: "developers/stone/header" },
+                {
+                  label: "V1",
+                  items: [
+                    { slug: "developers/stone/v1" },
+                    { slug: "developers/stone/v1/header" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
       ],
     }),
   ],
-})
+});

--- a/src/content/docs/Users/Desktops/cosmic.mdx
+++ b/src/content/docs/Users/Desktops/cosmic.mdx
@@ -11,12 +11,11 @@ choice with AerynOS users. Despite early alpha status, it is notable for being w
 a modern multiprocess architecture, while being Wayland-only. For many, this makes AerynOS and COSMIC an
 ideal partnership.
 
-<Aside type="tip">
-As of prealpha `0.4`, it is possible to install the COSMIC desktop directly at installation time using the
-desktop selection list in `lichen`, our system installer.
-</Aside>
-
 ### Installing COSMIC on AerynOS
+
+AerynOS currently only offers one iso with a GNOME live environment. However, `lichen` is a net based installer that allows users to select their Desktop Environment at install time. As such, you can install AerynOS COSMIC edition directly from the GNOME based AerynOS installer iso.
+
+If you already have a GNOME install and would like to try COSMIC, it is possible to install COSMIC on top of GNOME. This can be done by using the following command:
 
 ```bash
 sudo moss install cosmic-desktop
@@ -24,5 +23,17 @@ sudo moss install cosmic-desktop
 
 ### Controlling the display manager
 
-If you've installed COSMIC over the top of a GNOME install, you can safely remove `gdm` and have
-`cosmic-greeter` take over. Note: GNOME Shell still expects `gdm` for full functionality.
+If you've installed COSMIC over the top of a GNOME install, you can still log into your COSMIC session from `gdm`. You can also safely remove `gdm` and have `cosmic-greeter` take over. Note: GNOME Shell still expects `gdm` for full functionality.
+
+#### Installing cosmic-greeter
+
+```bash
+sudo moss install cosmic-greeter
+```
+
+#### Removing gdm
+If you wish to remove `gdm`, you would use the following command:
+
+```bash
+sudo moss remove gdm
+```

--- a/src/content/docs/Users/Desktops/gnome.mdx
+++ b/src/content/docs/Users/Desktops/gnome.mdx
@@ -8,7 +8,7 @@ The default desktop environemnt for the AerynOS live environment and for install
 
 GNOME has been chosen as the default environment due to our familiarity with the GNOME software stack and therefore our ability to maintain it whilst we work on fleshing out the AerynOS tooling an infrastructure.
 
-Our defaults:
+### Gnome defaults
 
 * Terminal: [ptyxis](https://gitlab.gnome.org/chergert/ptyxis)
 * Media Player: [Celluloid](https://celluloid-player.github.io/)

--- a/src/content/docs/Users/Desktops/gnome.mdx
+++ b/src/content/docs/Users/Desktops/gnome.mdx
@@ -8,6 +8,8 @@ The default desktop environemnt for the AerynOS live environment and for install
 
 GNOME has been chosen as the default environment due to our familiarity with the GNOME software stack and therefore our ability to maintain it whilst we work on fleshing out the AerynOS tooling an infrastructure.
 
+It is recommended to install GNOME using `lichen`, rather than adding to an existing install.
+
 ### Gnome defaults
 
 * Terminal: [ptyxis](https://gitlab.gnome.org/chergert/ptyxis)

--- a/src/content/docs/Users/Desktops/gnome.mdx
+++ b/src/content/docs/Users/Desktops/gnome.mdx
@@ -1,10 +1,16 @@
 ---
 title: 'GNOME'
-lastUpdated: 2024-09-10T00:07:13Z
+lastUpdated: 2025-08-04T20:06:00Z
 description: "GNOME Desktop"
 ---
 
-Until `prealpha 0.4`, we defaulted to the GNOME Desktop for our ISOs. It is now possible
-to select the desktop yourself, and to download GNOME or COSMIC versions of our live ISO.
+The default desktop environemnt for the AerynOS live environment and for installs using `lichen` is [GNOME](https://www.gnome.org/). We utilise Wayland display server protocol and do not offer X11 (or any fork of X11).
 
-It is recommended to install GNOME using `lichen`, rather than adding to an existing install.
+Our defaults:
+
+* Terminal: [ptyxis](https://gitlab.gnome.org/chergert/ptyxis)
+* Media Player: [Celluloid](https://celluloid-player.github.io/)
+* Software: [Gnome Software](https://apps.gnome.org/en/Software/)
+* Document Viewer: [Gnome Papers](https://apps.gnome.org/en/Papers/)
+* System Monitor: [Gnome Resources](https://apps.gnome.org/en/Resources/)
+* Code editor: [Zed](https://zed.dev/)

--- a/src/content/docs/Users/Desktops/gnome.mdx
+++ b/src/content/docs/Users/Desktops/gnome.mdx
@@ -6,6 +6,8 @@ description: "GNOME Desktop"
 
 The default desktop environemnt for the AerynOS live environment and for installs using `lichen` is [GNOME](https://www.gnome.org/). We utilise Wayland display server protocol and do not offer X11 (or any fork of X11).
 
+GNOME has been chosen as the default environment due to our familiarity with the GNOME software stack and therefore our ability to maintain it whilst we work on fleshing out the AerynOS tooling an infrastructure.
+
 Our defaults:
 
 * Terminal: [ptyxis](https://gitlab.gnome.org/chergert/ptyxis)

--- a/src/content/docs/Users/Desktops/plasma.mdx
+++ b/src/content/docs/Users/Desktops/plasma.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Plasma'
+lastUpdated: 2025-08-04T20:06:00Z
+description: "KDE Plasma Desktop"
+---
+
+
+AerynOS now offers [KDE Plasma](https://kde.org/plasma-desktop/) as a Desktop Environment though it is currently considered beta staus. You can track the progress of identifying and resolving Plasma related issues on [Github](https://github.com/AerynOS/recipes/issues/952).
+
+#### Installing Plasma on an existing AerynOS install
+
+If you are already using GNOME, you are able to install KDE Plasma side by side and select which Desktop Environment to use in `GDM` at login. You do this by installing one of three package sets:
+
+```
+sudo moss install pkgset-aeryn-plasma-minimal
+sudo moss install pkgset-aeryn-plasma-recommended
+sudo moss install pkgset-aeryn-plasma-full
+```
+
+The names are fairly self explanatory:
+* Minimal: The minimum number of packages required for a Plasma desktop session
+* Recommended: The Plasma desktop session plus additional recommended applications
+* Full: The Plasma desktop session plus all available KDE applications
+
+
+#### Replacing GDM
+
+You can log into a KDE Plasma session via `GDM` however you also have the option to install `SDDM` or `plasma-login-manager`
+
+```sudo moss install SDDM```
+
+or
+
+```sudo moss install plasma-login-manager```

--- a/src/content/docs/Users/Desktops/plasma.mdx
+++ b/src/content/docs/Users/Desktops/plasma.mdx
@@ -7,7 +7,7 @@ description: "KDE Plasma Desktop"
 
 AerynOS now offers [KDE Plasma](https://kde.org/plasma-desktop/) as a Desktop Environment though it is currently considered beta staus. You can track the progress of identifying and resolving Plasma related issues on [Github](https://github.com/AerynOS/recipes/issues/952).
 
-#### Installing Plasma on an existing AerynOS install
+### Installing Plasma on an existing AerynOS install
 
 If you are already using GNOME, you are able to install KDE Plasma side by side and select which Desktop Environment to use in `GDM` at login. You do this by installing one of three package sets:
 
@@ -23,7 +23,7 @@ The names are fairly self explanatory:
 * Full: The Plasma desktop session plus all available KDE applications
 
 
-#### Replacing GDM
+### Replacing GDM
 
 You can log into a KDE Plasma session via `GDM` however you also have the option to install `SDDM` or `plasma-login-manager`
 

--- a/src/content/docs/Users/Desktops/plasma.mdx
+++ b/src/content/docs/Users/Desktops/plasma.mdx
@@ -11,7 +11,7 @@ AerynOS now offers [KDE Plasma](https://kde.org/plasma-desktop/) as a Desktop En
 
 If you are already using GNOME, you are able to install KDE Plasma side by side and select which Desktop Environment to use in `GDM` at login. You do this by installing one of three package sets:
 
-```
+```bash
 sudo moss install pkgset-aeryn-plasma-minimal
 sudo moss install pkgset-aeryn-plasma-recommended
 sudo moss install pkgset-aeryn-plasma-full
@@ -27,8 +27,12 @@ The names are fairly self explanatory:
 
 You can log into a KDE Plasma session via `GDM` however you also have the option to install `SDDM` or `plasma-login-manager`
 
-```sudo moss install SDDM```
+```bash
+sudo moss install SDDM
+```
 
 or
 
-```sudo moss install plasma-login-manager```
+```bash
+sudo moss install plasma-login-manager
+```

--- a/src/content/docs/Users/Desktops/plasma.mdx
+++ b/src/content/docs/Users/Desktops/plasma.mdx
@@ -23,16 +23,25 @@ The names are fairly self explanatory:
 * Full: The Plasma desktop session plus all available KDE applications
 
 
-### Replacing GDM
+### Controlling the display manager
 
-You can log into a KDE Plasma session via `GDM` however you also have the option to install `SDDM` or `plasma-login-manager`
+If you've installed Plasma over the top of a GNOME install, you can still log into your Plasma session from `gdm`. You can also safely remove `gdm` and have either `sddm` or `plasma-login-manager` take over. Note: GNOME Shell still expects `gdm` for full functionality.
+
+#### Installing either sddm or plasma-login-manager
 
 ```bash
-sudo moss install SDDM
+sudo moss install sddm
 ```
 
 or
 
 ```bash
 sudo moss install plasma-login-manager
+```
+
+#### Removing gdm
+If you wish to remove `gdm`, you would use the following command:
+
+```bash
+sudo moss remove gdm
 ```


### PR DESCRIPTION
Update the GNOME and COSMIC desktop pages and create a new page for Plasma.

- I have not yet adapted the COSMIC page to reference pkgset as the cosmic pkgset's have not yet been fleshed out
- I have not yet created a page for Sway but again, I think the Sway pkgset needs work
- GNOME is listed as the default / recommended option for now