### PR TITLE
Add header social links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,8 @@ export default defineConfig({
       title: "AerynOS Docs",
       social: {
         github: "https://github.com/AerynOS/dotdev",
+        matrix: "https://matrix.to/#/#aerynos:matrix.org",
+        mastodon: "https://hachyderm.io/@AerynOS",
       },
       customCss: ["@/styles/global.css"],
       plugins: [starlightLinksValidator()],


### PR DESCRIPTION
This change adds the Matrix and Mastadon social links into our wiki header with corresponding icons. It's part of a set of QOL changes that I'm working on for the wiki.