### PR TITLE
Edit page Github

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,6 +18,9 @@ export default defineConfig({
         github: "https://github.com/AerynOS/dotdev",
       },
       customCss: ["@/styles/global.css"],
+      editLink: {
+        baseUrl: "https://github.com/AerynOS/dotdev/edit/main/",
+      },
       plugins: [starlightLinksValidator()],
       sidebar: [
         {


### PR DESCRIPTION
This Change adds an edit button at the bottom that links to the corresponding Github page for the Wiki. Allowing people to easily edit it directly on Github or to be immediately directed to the correct file to edit. 