### PR TITLE
ci: Add Dependabot config for npm updates

### DIFF
--- a/.github/workflows/.github/dependabot.yml
+++ b/.github/workflows/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Add a Dependabot configuration to automatically check for npm dependency updates and open PRs on a monthly cadence. This reduces manual upkeep and keeps dependencies current.

Key changes

Add .github/dependabot.yml to enable npm update checks.

Configure update cadence on a monthly basis to reduce noise

Rationale

Dependabot will create automated PRs for dependency bumps, making it easier to stay up to date and address security advisories promptly.