### PR TITLE
Creating a new recipe: Fix command guidance

### DIFF
--- a/src/content/docs/Packaging/Workflow/creating-a-new-recipe.mdx
+++ b/src/content/docs/Packaging/Workflow/creating-a-new-recipe.mdx
@@ -56,7 +56,7 @@ The Nano "bleeding edge" page lists the following tools you should keep in mind:
 We use `boulder` to help create the recipe using the `boulder recipe new` command. This command will generate a skeleton recipe for you to fill in. `boulder` will read the contents of the source code of the package you are trying to add and automatically create a `stone.yaml` recipe file and a `monitoring.yaml` file.
 
 ```bash
-boulder recipe update "upstream URL"
+boulder recipe new "upstream URL"
 ```
 
 In the example of Nano, to create a recipe based on version 8.7, you would use the following command:


### PR DESCRIPTION
Fix an error where we reference "boulder recipe update" instead of boulder recipe new"