### PR TITLE
workflow: Use cdn streams for both moss and boulder

### DIFF
--- a/src/content/docs/Packaging/Workflow/basic-workflow.mdx
+++ b/src/content/docs/Packaging/Workflow/basic-workflow.mdx
@@ -52,21 +52,21 @@ Boulder will need to have its list of "build profiles" be updated before it will
 boulder profile list
 # output
 default-x86_64:
-  - volatile = https://build.aerynos.dev/volatile/x86_64/stone.index [0]
+  - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [0]
 
 # add new local-x86_64 build profile
 # note: ${HOME} will be replaced by the actual home directory of the user
 #       invoking the command. In the example below, ${HOME} = /home/ermo
 boulder profile add \
-  --repo name=volatile,uri=https://build.aerynos.dev/stream/volatile/x86_64/stone.index,priority=0 \
+  --repo name=volatile,uri=https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index,priority=0 \
   --repo name=local,uri=file://${HOME}/.cache/local_repo/x86_64/stone.index,priority=100 \
   local-x86_64
 boulder profile list
 # output
 default-x86_64:
- - volatile = https://build.aerynos.dev/volatile/x86_64/stone.index [0]
+ - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [0]
 local-x86_64:
- - volatile = https://build.aerynos.dev/stream/volatile/x86_64/stone.index [0]
+ - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [0]
  - local = file:///home/ermo/.cache/local_repo/x86_64/stone.index [100]
 ```
 
@@ -84,7 +84,7 @@ local-x86_64:
       active: true
     volatile:
       description: ''
-      uri: https://build.aerynos.dev/stream/volatile/x86_64/stone.index
+      uri: https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index
       priority: 0
       active: true
 ```
@@ -98,16 +98,16 @@ Listing and adding moss-format repositories containing stone.index files is done
 ```bash
 moss repo list
 # output
- - unstable = https://cdn.aerynos.dev/unstable/x86_64/stone.index [0]
+ - unstable = https://cdn.aerynos.dev/stream/unstable/x86_64/stone.index [0]
 # add repositories
 # note: ${HOME} will be replaced by the actual home directory of the user
 #       invoking the command. In the example below, ${HOME} = /home/ermo"
-sudo moss repo add volatile https://build.aerynos.dev/stream/volatile/x86_64/stone.index -p 10
+sudo moss repo add volatile https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index -p 10
 sudo moss repo add local file://${HOME}/.cache/local_repo/x86_64/stone.index -p 100
 moss repo list
 # output
- - unstable = https://cdn.aerynos.dev/unstable/x86_64/stone.index [0]
- - volatile = https://build.aerynos.dev/stream/volatile/x86_64/stone.index [10]
+ - unstable = https://cdn.aerynos.dev/stream/unstable/x86_64/stone.index [0]
+ - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [10]
  - local = file:///home/ermo/.cache/local_repo/x86_64/stone.index [100]
 ```
 
@@ -128,8 +128,8 @@ sudo moss repo disable volatile
 sudo moss repo disable local
 moss repo list
 # output
- - unstable = https://cdn.aerynos.dev/unstable/x86_64/stone.index [0]
- - volatile = https://build.aerynos.dev/stream/volatile/x86_64/stone.index [10] (disabled)
+ - unstable = https://cdn.aerynos.dev/stream/unstable/x86_64/stone.index [0]
+ - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [10] (disabled)
  - local = file:///home/ermo/.cache/local_repo/x86_64/stone.index [100] (disabled)
 ```
 
@@ -145,8 +145,8 @@ sudo moss repo enable volatile
 sudo moss repo enable local
 moss repo list
 # output
- - unstable = https://cdn.aerynos.dev/unstable/x86_64/stone.index [0]
- - volatile = https://build.aerynos.dev/stream/volatile/x86_64/stone.index [10]
+ - unstable = https://cdn.aerynos.dev/stream/unstable/x86_64/stone.index [0]
+ - volatile = https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index [10]
  - local = file:///home/ermo/.cache/local_repo/x86_64/stone.index [100]
 ```
 


### PR DESCRIPTION
This is mostly a convenience update that will enable us to control the URIs manually, now that we control CDN settings directly via caddy configuration directives on the repository side.