### PR TITLE
global.css: Update colours and site width

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,7 +15,8 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-5: #39373e;
 	--sl-color-gray-6: #27262c;
 	--sl-color-black: #18181b;
-	--sl-content-width: 80rem;
+	--sl-content-width: 70rem;
+	--sl-breakpoint-lg: 100rem;
 }
 /* Light mode colors. */
 :root[data-theme='light'] {
@@ -31,5 +32,6 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-6: #eeedf1;
 	--sl-color-gray-7: #f6f6f8;
 	--sl-color-black: #ffffff;
-	--sl-content-width: 80rem;
+	--sl-content-width: 70rem;
+	--sl-breakpoint-lg: 100rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,9 +4,9 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 
 /* Dark mode colors. */
 :root {
-	--sl-color-accent-low: #36113e;
-	--sl-color-accent: #a400c0;
-	--sl-color-accent-high: #e3b6ed;
+	--sl-color-accent-low: #f0bb78ff;
+	--sl-color-accent: #f5ecd5;
+	--sl-color-accent-high: #626f47ff;
 	--sl-color-white: #ffffff;
 	--sl-color-gray-1: #eeedf1;
 	--sl-color-gray-2: #c9c7cc;
@@ -15,12 +15,13 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-5: #39373e;
 	--sl-color-gray-6: #27262c;
 	--sl-color-black: #18181b;
+	--sl-content-width: 80rem;
 }
 /* Light mode colors. */
 :root[data-theme='light'] {
-	--sl-color-accent-low: #ebc9f3;
-	--sl-color-accent: #8b00a3;
-	--sl-color-accent-high: #4e0e5b;
+	--sl-color-accent-low: #d3a569d4;
+	--sl-color-accent: #626f47ff;
+	--sl-color-accent-high: #A4B465;
 	--sl-color-white: #18181b;
 	--sl-color-gray-1: #27262c;
 	--sl-color-gray-2: #39373e;
@@ -30,4 +31,5 @@ https://starlight.astro.build/guides/css-and-tailwind/#color-theme-editor
 	--sl-color-gray-6: #eeedf1;
 	--sl-color-gray-7: #f6f6f8;
 	--sl-color-black: #ffffff;
+	--sl-content-width: 80rem;
 }


### PR DESCRIPTION
# Summary

- Use new branding colours
- Update max site width to look better on higher resolution displays


# Testing

- Checked on 5k2k display
- Screenshots below showing both light and dark theme

Note that you will need to open the screenshots as they will be squashed when viewed in github otherwise.



**Current dark theme**
<img width="5128" height="2160" alt="Current_Dark_5k" src="https://github.com/user-attachments/assets/ada27260-9b42-45e0-a363-8fedd4c01049" />


**Current light theme**
<img width="5130" height="2160" alt="Current_Light_5k" src="https://github.com/user-attachments/assets/196af459-48dc-42ad-9ca2-c488ff741889" />

**New dark theme**
<img width="5130" height="2160" alt="New_Dark_5k" src="https://github.com/user-attachments/assets/e02964a7-39a6-44d2-8203-2525dfdfe82f" />

**Current light theme**
<img width="5120" height="2160" alt="New_Light_5k" src="https://github.com/user-attachments/assets/14f18dca-931d-4d4d-878c-bfc06fdd61c0" />
