### PR TITLE
preerequisites: Update to change from repos to Projects

### DIFF
--- a/src/content/docs/Packaging/Workflow/prerequisites.mdx
+++ b/src/content/docs/Packaging/Workflow/prerequisites.mdx
@@ -27,8 +27,8 @@ The easiest way to create a local repository is to use the helper script distrib
 Start by cloning the recipes/ git repository:
 
 ```bash
-mkdir -pv repos/aerynos/
-pushd repos/aerynos
+mkdir -pv Projects/aerynos/
+pushd Projects/aerynos
 git clone https://github.com/AerynOS/recipes
 ```
 
@@ -37,7 +37,7 @@ After the recipes/ git repository has been cloned, symlink helpers.bash into `~/
 ```bash
 popd
 mkdir -pv ~/.bashrc.d/
-ln -sv ~/repos/aerynos/recipes/tools/helpers.bash ~/.bashrc.d/90-aerynos-helpers.bash
+ln -sv ~/Projects/aerynos/recipes/tools/helpers.bash ~/.bashrc.d/90-aerynos-helpers.bash
 ```
 
 Finally, execute the following in a new terminal tab:


### PR DESCRIPTION
**Summary**

There is a new XDG standard to have a Projects folder in your home directory. Proposal to shift the default location of aerynos recipes repo to this Projects folder when setting up packaging workflow rather than creating a new repo folder in a packagers home directory

**Testing**

I am setting up a new install of aerynOS and I have manually shifted to use Projects/aerynos rather than repos/aerynos as part of my packaging workflow setup and it worked fine.